### PR TITLE
PGPLOT.pm: fix typo caught by lintian.

### DIFF
--- a/PGPLOT.pm
+++ b/PGPLOT.pm
@@ -53,7 +53,7 @@ PGPLOT - allow subroutines in the PGPLOT graphics library to be called from Perl
 
 =head1 DESCRIPTION
 
-This module provides an inteface to the PGPLOT graphics library. To
+This module provides an interface to the PGPLOT graphics library. To
 obtain the library and its manual, see L</OBTAINING PGPLOT>.
 
 For every PGPLOT function the module provides an equivalent Perl


### PR DESCRIPTION
While working on the debian package libpgplot-perl, the spell checker
integrated in lintian caught a case of:

	inteface -> interface

I thought you might be interested in getting this addressed.

Signed-off-by: Étienne Mollier <emollier@debian.org>