### PR TITLE
Fix build failures with standard C 2023.

### DIFF
--- a/PGPLOT.xs
+++ b/PGPLOT.xs
@@ -306,7 +306,7 @@ pgconx(a,idim,jdim,i1,i2,j1,j2,c,nc,plot)
   CODE:
     DEBUG_PRINT(pgconx);
     pgfunname[0] = plot;
-    cpgconx(a,idim,jdim,i1,i2,j1,j2,c,nc,pgfunplot);
+    cpgconx(a,idim,jdim,i1,i2,j1,j2,c,nc,(void(*)(void))pgfunplot);
 
 
 void
@@ -462,7 +462,7 @@ pgfunt(fx,fy,n,tmin,tmax,pgflag)
     DEBUG_PRINT(pgfunt);
     pgfunname[0] = fx;
     pgfunname[1] = fy;
-    cpgfunt(pgfun1,pgfun2,n,tmin,tmax,pgflag);
+    cpgfunt((float(*)(void))pgfun1,(float(*)(void))pgfun2,n,tmin,tmax,pgflag);
 
 
 void
@@ -475,7 +475,7 @@ pgfunx(fy,n,xmin,xmax,pgflag)
   CODE:
     DEBUG_PRINT(pgfunx);
     pgfunname[0] = fy;
-    cpgfunx(pgfun1,n,xmin,xmax,pgflag);
+    cpgfunx((float(*)(void))pgfun1,n,xmin,xmax,pgflag);
 
 
 void
@@ -488,7 +488,7 @@ pgfuny(fx,n,ymin,ymax,pgflag)
   CODE:
     DEBUG_PRINT(pgfuny);
     pgfunname[0] = fx;
-    cpgfuny(pgfun1,n,ymin,ymax,pgflag);
+    cpgfuny((float(*)(void))pgfun1,n,ymin,ymax,pgflag);
 
 
 void

--- a/pgfun.c
+++ b/pgfun.c
@@ -26,9 +26,9 @@
 /* Prototypes */
 
 static SV*  pgfunname[2];
-float pgfun1();
-float pgfun2();
-void   pgfunplot();
+float pgfun1(float *x);
+float pgfun2(float *x);
+void   pgfunplot(int *visible,float *x, float *y, float *z);
 void PGFUNX(float fy(), int *n, float *xmin, float *xmax, int *pgflag);
 void PGFUNY(float fx(), int *n, float *ymin, float *ymax, int *pgflag);
 void PGFUNT(float fx(), float fy(), int *n, float *tmin, float *tmax, int *pgflag);


### PR DESCRIPTION
As initially identified in [Debian bug #1097250], PGPLOT is affected by build failures caused by mismatching prototypes with Gcc 15:

	In file included from PGPLOT.xs:16:
	pgfun.c: In function ‘pgfun1’:
	pgfun.c:78:7: warning: old-style function definition [-Wold-style-definition]
	   78 | float pgfun1(x)
	      |       ^~~~~~
	pgfun.c:79:4: error: number of arguments doesn’t match prototype
	   79 |    float *x; {
	      |    ^~~~~
	pgfun.c:29:7: error: prototype declaration
	   29 | float pgfun1();
	      |       ^~~~~~
	pgfun.c: In function ‘pgfun2’:
	pgfun.c:120:7: warning: old-style function definition [-Wold-style-definition]
	  120 | float pgfun2(x)
	      |       ^~~~~~
	pgfun.c:121:4: error: number of arguments doesn’t match prototype
	  121 |    float *x; {
	      |    ^~~~~
	pgfun.c:30:7: error: prototype declaration
	   30 | float pgfun2();
	      |       ^~~~~~
	pgfun.c: In function ‘pgfunplot’:
	pgfun.c:161:6: warning: old-style function definition [-Wold-style-definition]
	  161 | void pgfunplot(visible,x,y,z)
	      |      ^~~~~~~~~
	pgfun.c:163:4: error: number of arguments doesn’t match prototype
	  163 |    float *x,*y,*z; {
	      |    ^~~~~
	pgfun.c:31:8: error: prototype declaration
	   31 | void   pgfunplot();
	      |        ^~~~~~~~~

This patch adds missing function argument types in prototypes, and casts a couple of indirect function calls, to ensure compatibility with the standard C 2023, now selected by default by gcc 15 and later.

[Debian bug #1097250]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1097250